### PR TITLE
Improve build speed

### DIFF
--- a/i3df/build.rs
+++ b/i3df/build.rs
@@ -108,6 +108,8 @@ fn write_code_to_file(filename: &String, code: &proc_macro2::TokenStream) -> Res
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Tell cargo only to rerun the build script if it itself changes
+    println!("cargo:rerun-if-changed=build.rs");
 
     let spec: Spec = serde_yaml::from_str(i3df_specification::as_string().as_str())?;
 

--- a/i3df/build.rs
+++ b/i3df/build.rs
@@ -82,7 +82,10 @@ fn create_dtype(attribute: &Attribute) -> TokenStream {
             "u32" => quote! {u32},
             "u64" => quote! {u64},
             "f32" => quote! {f32},
-            t => quote! { ERROR_NOT_IMPLEMENTED: #t },
+             t => {
+               let message = format!("Type not implemented: {}", t);
+               quote!{ compile_error!(#message) }
+             },
         },
         Type::Texture(_) => quote! { Texture },
     };

--- a/i3df/build.rs
+++ b/i3df/build.rs
@@ -83,8 +83,7 @@ fn create_dtype(attribute: &Attribute) -> TokenStream {
             "u64" => quote! {u64},
             "f32" => quote! {f32},
              t => {
-               let message = format!("Type not implemented: {}", t);
-               quote!{ compile_error!(#message) }
+               panic!("Type not implemented: {}", t);
              },
         },
         Type::Texture(_) => quote! { Texture },

--- a/i3df/src/lib.rs
+++ b/i3df/src/lib.rs
@@ -55,54 +55,6 @@ pub struct SectorHeader {
     pub attributes: Option<SectorAttributes>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct SectorAttributes {
-    pub color: Vec<[u8; 4]>,
-    pub diagonal: Vec<f32>,
-    pub center_x: Vec<f32>,
-    pub center_y: Vec<f32>,
-    pub center_z: Vec<f32>,
-    pub normal: Vec<[f32; 3]>,
-    pub delta: Vec<f32>,
-    pub height: Vec<f32>,
-    pub radius: Vec<f32>,
-    pub angle: Vec<f32>,
-    pub translation_x: Vec<f32>,
-    pub translation_y: Vec<f32>,
-    pub translation_z: Vec<f32>,
-    pub scale_x: Vec<f32>,
-    pub scale_y: Vec<f32>,
-    pub scale_z: Vec<f32>,
-    pub file_id: Vec<u64>,
-    pub texture: Vec<Texture>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct SectorAttribute {
-    pub item_count: u32,
-    pub item_size: u32,
-
-    pub attribute_data: SectorAttributeData,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum SectorAttributeData {
-    Color(Vec<(u8, u8, u8, u8)>),
-    Normal(Vec<(f32, f32, f32)>),
-    Float32(Vec<f32>),
-    Uint64(Vec<u64>),
-    Texture(Vec<Texture>),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Texture {
-    pub file_id: u64,
-    pub width: u16,
-    pub height: u16,
-}
-
 pub fn parse_scene(reader: impl BufRead) -> Result<Scene, Error> {
     parse_scene_data(reader)
 }


### PR DESCRIPTION
This reduces the build time from 60 s to 6 s when files like
i3df/src/renderables.rs change, making the feedback loop a lot more
comfortable to work with. In addition, it reduces the build time for initial builds by extracting certain functions to reduce duplication in the generated file.